### PR TITLE
feat: add ability to run apps from the launchpad

### DIFF
--- a/README.org
+++ b/README.org
@@ -160,6 +160,66 @@ in
 }
 #+end_src
 
+*** Others Flakes without nix-darwin nor home-manager
+
+This will install apps local for a project available in the launchpad
+
+Example:
+
+#+begin_src nix
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.nixcasks.url = "github:jacekszymanski/nixcasks";
+  inputs.nixcasks.inputs.nixpkgs.follows = "nixpkgs";
+
+  inputs.mac-app-util.url = "github:hraban/mac-app-util";
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , mac-app-util
+    , nixcasks
+    , ...
+    }:
+    flake-utils.lib.eachDefaultSystem (system: {
+      devShells.default =
+        let
+          osVersion = "sonoma";
+
+          nixcasksOverlay = final: prev: {
+            nixcasks = (nixcasks.output {
+              inherit osVersion;
+            }).packages."${prev.system}";
+          };
+
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+            overlays = [
+              nixcasksOverlay
+            ];
+          };
+
+          brewPackages = [
+            pkgs.nixcasks.android-studio
+            pkgs.nixcasks.firefox
+          ];
+        in
+        pkgs.mkShellNoCC {
+          shellHook = ''
+            # make apps available in the launcher and up to date in the dock
+            ${pkgs.lib.getExe mac-app-util.packages."${system}".shellHook} \
+              ${mac-app-util.lib.assembleBrewAppsInOneFolder { inherit pkgs brewPackages; }} \
+              "Nix_Flake_Example"
+          '';
+        };
+    });
+}
+#+end_src
+
 ** Commands
 
 At the core of this project is a (Nix-agnostic) program that can:

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,1 @@
+flake.lock

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -1,0 +1,52 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.nixcasks.url = "github:jacekszymanski/nixcasks";
+  inputs.nixcasks.inputs.nixpkgs.follows = "nixpkgs";
+
+  # inputs.mac-app-util.url = "github:hraban/mac-app-util";
+  inputs.mac-app-util.url = "../.";
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , mac-app-util
+    , nixcasks
+    , ...
+    }:
+    flake-utils.lib.eachDefaultSystem (system: {
+      devShells.default =
+        let
+          osVersion = "sonoma";
+
+          nixcasksOverlay = final: prev: {
+            nixcasks = (nixcasks.output {
+              inherit osVersion;
+            }).packages."${prev.system}";
+          };
+
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+            overlays = [
+              nixcasksOverlay
+            ];
+          };
+
+          brewPackages = [
+            pkgs.nixcasks.android-studio
+            pkgs.nixcasks.firefox
+          ];
+        in
+        pkgs.mkShellNoCC {
+          shellHook = ''
+            # make apps available in the launcher and up to date in the dock
+            ${pkgs.lib.getExe mac-app-util.packages."${system}".shellHook} \
+              ${mac-app-util.lib.assembleBrewAppsInOneFolder { inherit pkgs brewPackages; }} \
+              "Nix_Flake_Example"
+          '';
+        };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,15 @@
           ${mac-app-util}/bin/mac-app-util sync-trampolines "/Applications/Nix Apps" "/Applications/Nix Trampolines"
         '';
       };
+      lib.assembleBrewAppsInOneFolder = { pkgs, brewPackages }:
+        pkgs.runCommand "assembleBrewAppsInOneFolder" { } ''
+          mkdir --parents $out
+          for PACKAGE in ${builtins.concatStringsSep " " brewPackages}; do
+            for APP in "$PACKAGE"/*/*.app; do
+              ln --symbolic "$APP" "$out"
+            done
+          done
+        '';
     }
     //
     (with flake-utils.lib; eachDefaultSystem (system:
@@ -100,6 +109,19 @@
             doInstallCheck = true;
             meta.license = pkgs.lib.licenses.agpl3Only;
           }) {};
+
+          shellHook =
+            let
+              is-on-mac = builtins.hasAttr system self.packages;
+              mac-app-util = self.packages.${system}.default;
+            in
+            pkgs.writeShellScriptBin "mac-app-util-shell-hook" (
+              if is-on-mac then ''
+                fromDir="$1"
+                toDir="~/Applications/$2"
+                ${mac-app-util}/bin/mac-app-util sync-trampolines "$fromDir" "$toDir"
+              '' else ""
+            );
         };
       }));
 }


### PR DESCRIPTION
Hello,

This tool seems to work great when installing brew apps from nix-darwin nor home-manager :clap: 

Currently, when installing brew apps from a specific project (without nix-darwin nor home-manager), the app is not launchable from the launchpad

This PR is a proof of concept to start a discussion

How should we make apps installed from a specific project usable from the launchpad ?

<!--

  Thank you for opening a pull request.  I accept contributions to mac-app-util
  which are released in the “public domain.”

  This is *NOT A CLA*: you remain the author and copyright holder of this piece
  of code.  You just agree to grant everyone the rights to use it under the CC0
  license.

-->

**By submiting this PR, I agree to license this contribution under Creative Commons’ [CC0 license](https://creativecommons.org/public-domain/cc0/).**


