### PR TITLE
Nixfmt classic formatter

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,12 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 let
   lock = builtins.fromJSON (builtins.readFile ./flake.lock);
   sourceInfo = lock.nodes.flake-compat.locked;
   flake-compat = fetchTarball {
-    url = "https://github.com/${sourceInfo.owner}/${sourceInfo.repo}/archive/${sourceInfo.rev}.tar.gz";
+    url =
+      "https://github.com/${sourceInfo.owner}/${sourceInfo.repo}/archive/${sourceInfo.rev}.tar.gz";
     sha256 = sourceInfo.narHash;
   };
   flake = (pkgs.callPackage flake-compat { src = ./.; });
-in
-flake.defaultNix
+in flake.defaultNix

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,8 @@
 {
   inputs = {
     # This has SBCL 2.4.10 and docktuil 3.1.3 which are known to work
-    nixpkgs.url = "github:NixOS/nixpkgs/af51545ec9a44eadf3fe3547610a5cdd882bc34e";
+    nixpkgs.url =
+      "github:NixOS/nixpkgs/af51545ec9a44eadf3fe3547610a5cdd882bc34e";
     cl-nix-lite.url = "github:hraban/cl-nix-lite";
     flake-compat = {
       # Use my own fixed-output-derivation branch because I don’t want users to
@@ -38,70 +39,66 @@
             type = types.bool;
             default = builtins.hasAttr pkgs.stdenv.system self.packages;
             example = true;
-            description = "Whether to enable mac-app-util home manager integration";
+            description =
+              "Whether to enable mac-app-util home manager integration";
           };
         };
         config = lib.mkIf config.targets.darwin.mac-app-util.enable {
           home.activation = {
-            trampolineApps = let
-              mac-app-util = self.packages.${pkgs.stdenv.system}.default;
-            in lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-              fromDir="$HOME/Applications/Home Manager Apps"
-              toDir="$HOME/Applications/Home Manager Trampolines"
-              ${mac-app-util}/bin/mac-app-util sync-trampolines "$fromDir" "$toDir"
-            '';
+            trampolineApps =
+              let mac-app-util = self.packages.${pkgs.stdenv.system}.default;
+              in lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+                fromDir="$HOME/Applications/Home Manager Apps"
+                toDir="$HOME/Applications/Home Manager Trampolines"
+                ${mac-app-util}/bin/mac-app-util sync-trampolines "$fromDir" "$toDir"
+              '';
           };
         };
       };
       darwinModules.default = { pkgs, ... }: {
-        system.activationScripts.postActivation.text = let
-          mac-app-util = self.packages.${pkgs.stdenv.system}.default;
-        in ''
-          ${mac-app-util}/bin/mac-app-util sync-trampolines "/Applications/Nix Apps" "/Applications/Nix Trampolines"
-        '';
+        system.activationScripts.postActivation.text =
+          let mac-app-util = self.packages.${pkgs.stdenv.system}.default;
+          in ''
+            ${mac-app-util}/bin/mac-app-util sync-trampolines "/Applications/Nix Apps" "/Applications/Nix Trampolines"
+          '';
       };
-    }
-    //
-    (with flake-utils.lib; eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system}.extend cl-nix-lite.overlays.default;
-      in {
-        packages = {
-          default = pkgs.callPackage ({
-            lispPackagesLite
-          , dockutil
-          , findutils
-          , jq
-          , rsync
-          }: with lispPackagesLite; lispScript rec {
-            name = "mac-app-util";
-            src = ./main.lisp;
-            dependencies = [
-              alexandria
-              inferior-shell
-              cl-interpol
-              cl-json
-              str
-              trivia
-            ];
-            nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
-            postInstall = ''
-              wrapProgramBinary "$out/bin/${name}" \
-                --suffix PATH : "${with pkgs; lib.makeBinPath [
-                  dockutil
-                  rsync
-                  findutils
-                  jq
-                ]}"
-            '';
-            installCheckPhase = ''
-              $out/bin/${name} --help
-            '';
-            doInstallCheck = true;
-            meta.license = pkgs.lib.licenses.agpl3Only;
-          }) {};
-        };
+    } // (with flake-utils.lib;
+      eachDefaultSystem (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system}.extend
+            cl-nix-lite.overlays.default;
+        in {
+          packages = {
+            default = pkgs.callPackage
+              ({ lispPackagesLite, dockutil, findutils, jq, rsync }:
+                with lispPackagesLite;
+                lispScript rec {
+                  name = "mac-app-util";
+                  src = ./main.lisp;
+                  dependencies = [
+                    alexandria
+                    inferior-shell
+                    cl-interpol
+                    cl-json
+                    str
+                    trivia
+                  ];
+                  nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+                  postInstall = ''
+                    wrapProgramBinary "$out/bin/${name}" \
+                      --suffix PATH : "${
+                        with pkgs;
+                        lib.makeBinPath [ dockutil rsync findutils jq ]
+                      }"
+                  '';
+                  installCheckPhase = ''
+                    $out/bin/${name} --help
+                  '';
+                  doInstallCheck = true;
+                  meta.license = pkgs.lib.licenses.agpl3Only;
+                }) { };
+          };
 
-        formatter = pkgs.nixfmt-classic;
-      }));
+          formatter = pkgs.nixfmt-classic;
+        }));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -101,5 +101,7 @@
             meta.license = pkgs.lib.licenses.agpl3Only;
           }) {};
         };
+
+        formatter = pkgs.nixfmt-classic;
       }));
 }


### PR DESCRIPTION
This change sets the flake's formatter output to `nixfmt-classic` which is pretty close to your style.

<!--

  Thank you for opening a pull request.  I accept contributions to mac-app-util
  which are released in the “public domain.”

  This is *NOT A CLA*: you remain the author and copyright holder of this piece
  of code.  You just agree to grant everyone the rights to use it under the CC0
  license.

-->

**By submiting this PR, I agree to license this contribution under Creative Commons’ [CC0 license](https://creativecommons.org/public-domain/cc0/).**
