### PR TITLE
fixing: blank or wrong symbols for constructed trampolines

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -160,7 +160,14 @@
     (sh `("/usr/bin/osacompile" #\o ,trampoline #\e ,cmd))
     (sync-icons app trampoline)
     (copy-paths (infoplist app) (infoplist trampoline) *copyable-app-props*)
-    (sh `("/usr/bin/touch" ,trampoline))))
+    ;; Sometimes the OS displays blank or stock applescript icons for these
+    ;; generated apps in launchpad, finder, etc.  It’s not 100% clear why and
+    ;; it’s hard to reproduce but this seems to help.  Probably a race condition
+    ;; between generating the original wrapper and updating the icons.  A
+    ;; cleaner solution would be building the app bundle in a temporary
+    ;; directory and only copying it in when fully ready, but this works for
+    ;; now.
+    (sh `(touch ,trampoline))))
 
 (defun mktrampoline-bin (bin trampoline)
   ;; In order for applescript not to wait on the binary you must direct both

--- a/main.lisp
+++ b/main.lisp
@@ -159,7 +159,8 @@
   (let ((cmd (format NIL "do shell script \"open '~A'\"" app)))
     (sh `("/usr/bin/osacompile" #\o ,trampoline #\e ,cmd))
     (sync-icons app trampoline)
-    (copy-paths (infoplist app) (infoplist trampoline) *copyable-app-props*)))
+    (copy-paths (infoplist app) (infoplist trampoline) *copyable-app-props*)
+    (sh `("/usr/bin/touch" ,trampoline))))
 
 (defun mktrampoline-bin (bin trampoline)
   ;; In order for applescript not to wait on the binary you must direct both


### PR DESCRIPTION
Sometimes the symbols are „blank“. The trampolines are there, but most of the time the icons are partially replaced by the generic Apple placeholder for apps. Sometime even another symbol. It’s very weird.

<img width="344" alt="Screenshot 2025-03-10 at 19 12 21" src="https://github.com/user-attachments/assets/6945b628-3be2-4d8d-b88b-22cf5a8c3335" />

To resolve the issue, simply touching the `.app` folder at the end of the generation process suffices. I hope this patch is trivial and harmless enough to be included, even if you might not be able to replicate the problem.

I hope, I implemented that correctly, I have no idea of Lisp …

**By submiting this PR, I agree to license this contribution under Creative Commons’ [CC0 license](https://creativecommons.org/public-domain/cc0/).**
