### PR TITLE
trampoline icon not staying in dock anymore

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -128,7 +128,8 @@
                    (jq :argjson keys ,keys ,jqfilter (< orig) (> filtered))
                    (sh:pipe (cat bare-wrapper filtered)
                             (jq #\s add (> final)))
-                   (,*plutil* -convert xml1 -- final)))
+                   (,*plutil* -convert xml1 -- final)
+                   (,*plutil* -insert "LSUIElement" -bool true final)))
       (copy-file "final" to))))
 
 (defun resources (app)


### PR DESCRIPTION
Here’s another idea for a patch. On my system the trampoline’s icon appears and lingers in the "Stage Manager" part of the dock. A bit annoying, having two icons … this patch sets a flag in `Info.plist` and makes it disappear. I suppose, it is no problem for people having the trampoline pinned in the dock any way … but I prefer to keep my dock to a minimum.

<img width="382" alt="Screenshot 2025-03-19 at 13 23 48" src="https://github.com/user-attachments/assets/53718551-2e59-4db6-83b7-88521cf0feb7" />

Again, I have no idea of Lisp.  Especially, why I have to put `LSUIElement` in quotes for it not to be aa ¿variable?, but the rest of the command line is fine without quotes. 🤷

**By submiting this PR, I agree to license this contribution under Creative Commons’ [CC0 license](https://creativecommons.org/public-domain/cc0/).**
